### PR TITLE
Remove eval-when-compile

### DIFF
--- a/helm-describe-modes.el
+++ b/helm-describe-modes.el
@@ -42,7 +42,7 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'cl-lib))
+(require 'cl-lib)
 (require 'helm)
 
 (declare-function helm-elisp--persistent-help "helm-elisp")


### PR DESCRIPTION
Because this package uses cl-lib functions.
